### PR TITLE
Use stringex for automatic slug generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ bin/
 *.exe
 *.txt
 /vibelog
-
+/unidecode-yaml/*

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 	],
 	"dependencies": {
 		"vibe-d": "~>0.7.26-alpha.2",
-		"stringex": "~>0.0.1"
+		"stringex": "~>0.0.2"
 	},
 	"configurations": [
 		{

--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,8 @@
 		"Sönke Ludwig"
 	],
 	"dependencies": {
-		"vibe-d": "~>0.7.26-alpha.2"
+		"vibe-d": "~>0.7.26-alpha.2",
+		"stringex": "~>0.0.1"
 	},
 	"configurations": [
 		{

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -6,7 +6,7 @@
 		"tinyendian": "0.1.2",
 		"dyaml": "0.5.2",
 		"openssl": "1.1.4+1.0.1g",
-		"stringex": "0.0.1",
+		"stringex": "0.0.2",
 		"botan": "1.12.0+commit.23.g4c3802e",
 		"memutils": "0.4.1",
 		"vibe-d": "0.7.26-alpha.2+commit.23.ge67c277",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,7 +3,10 @@
 	"versions": {
 		"libevent": "2.0.1+2.0.16",
 		"libev": "5.0.0+4.04",
+		"tinyendian": "0.1.2",
+		"dyaml": "0.5.2",
 		"openssl": "1.1.4+1.0.1g",
+		"stringex": "0.0.1",
 		"botan": "1.12.0+commit.23.g4c3802e",
 		"memutils": "0.4.1",
 		"vibe-d": "0.7.26-alpha.2+commit.23.ge67c277",

--- a/source/vibelog/post.d
+++ b/source/vibelog/post.d
@@ -174,7 +174,7 @@ string makeSlugFromHeader(string header)
 			default:
 				ret.put('-');
 				break;
-			case '"', '\'', '´', '`', '.', ',', ';', '!', '?':
+			case '"', '\'', '´', '`', '.', ',', ';', '!', '?', '¿', '¡':
 				break;
 			case 'A': .. case 'Z'+1:
 				ret.put(cast(dchar)(ch - 'A' + 'a'));
@@ -188,7 +188,20 @@ string makeSlugFromHeader(string header)
 	return ret.data;
 }
 
-UniDecoder getDecoder() {
+unittest {
+	assert(makeSlugFromHeader("sample title") == "sample-title");
+	assert(makeSlugFromHeader("Sample Title") == "sample-title");
+	assert(makeSlugFromHeader("  Sample Title2  ") == "sample-title2");
+	assert(makeSlugFromHeader("反清復明") == "fan-qing-fu-ming");
+	assert(makeSlugFromHeader("φύλλο") == "phullo");
+	assert(makeSlugFromHeader("ខេមរភាសា") == "khemrbhaasaa");
+	assert(makeSlugFromHeader("zweitgrößte der Europäischen Union") == "zweitgrosste-der-europaischen-union");
+	assert(makeSlugFromHeader("østlige og vestlige del udviklede sig uafhængigt ") == "ostlige-og-vestlige-del-udviklede-sig-uafhaengigt");
+	assert(makeSlugFromHeader("¿pchnąć w tę łódź jeża lub ośm skrzyń fig?") == "pchnac-w-te-lodz-jeza-lub-osm-skrzyn-fig");
+	assert(makeSlugFromHeader("¼ €") == "1-4-eu");
+}
+
+private UniDecoder getDecoder() {
 	if (unidecoder is null) {
 		unidecoder = new UniDecoder();
 	}

--- a/source/vibelog/post.d
+++ b/source/vibelog/post.d
@@ -8,7 +8,10 @@ import vibe.textfilter.html;
 
 import std.array;
 import std.conv;
+import std.string : strip;
 public import std.datetime;
+
+import stringex.unidecode;
 
 
 final class Post {
@@ -33,7 +36,7 @@ final class Post {
 	}
 
 	@property string name() const { return slug.length ? slug : id.toString(); }
-	
+
 	static Post fromBson(Bson bson)
 	{
 		auto ret = new Post;
@@ -52,7 +55,7 @@ final class Post {
 			ret.tags ~= cast(string)t;
 		return ret;
 	}
-	
+
 	Bson toBson()
 	const {
 		Bson[] btags;
@@ -134,7 +137,7 @@ final class Comment {
 		ret.content = cast(string)bson["content"];
 		return ret;
 	}
-	
+
 	Bson toBson()
 	const {
 		Bson[string] ret;
@@ -160,10 +163,13 @@ final class Comment {
 	}
 }
 
+UniDecoder unidecoder;
+
 string makeSlugFromHeader(string header)
 {
 	Appender!string ret;
-	foreach( dchar ch; header ){
+	auto decoded_header = getDecoder().decode(header);
+	foreach( dchar ch; strip(decoded_header) ){
 		switch( ch ){
 			default:
 				ret.put('-');
@@ -180,4 +186,11 @@ string makeSlugFromHeader(string header)
 		}
 	}
 	return ret.data;
+}
+
+UniDecoder getDecoder() {
+	if (unidecoder is null) {
+		unidecoder = new UniDecoder();
+	}
+	return unidecoder;
 }


### PR DESCRIPTION
Some time ago I created a partial port of ruby Stringex library to convert unicode characters into their "romanized" counterparts. Automatic slug generation for blog post is an ideal application for that. So here is a PR adding support for that.

After those changes if I have a post entitles, for example, `反清復明` I will no longer end up with slug `----` but with `fan-qing-fu-ming`.

I was only able to test it with standalone blog, as it seems that embedding does not work with master at all (missing `vibelog.d` file).