### PR TITLE
Added options for filters, encapsulated WebAdmin data, fixed previewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Setting everything up
 
 2. Open the user management page and create a new user. Be sure to make the new user an administrator. The `admin` user will be disabled afterwards.
 
-3. Open the configuration management page and edit the `global` configuration. You should add at least one category here. Each line in the text field represents one configuration and must not contain spaces.
+3. Open the configuration management page and edit the `global` configuration. You can add categories by entering them into the first field, line by line. Category names must not contain spaces.
 
-4. Now edit the active configuration (`example`) and check all categories that should be listed on the blog.
+4. Now you may edit the active configuration (`example`) and check the categories that should be included on the blog or change the blog name and description.
 
 
 Posting articles

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ Embedding VibeLog into your own application
 
 		$ dub run
 
-You will probably also want to copy the views/layout.dt file to your own project and modify it to your needs (e.g. by adding a style sheet). The blog is accessible at <http://127.0.0.1:8080>.
+You will probably also want to copy the views/layout.dt file to your own project and modify it to your needs (e.g. by adding a style sheet). The blog is accessible at <http://127.0.0.1:8080/blog/>.
 
 
 Setting everything up
 ---------------------
 
-1. Go to the management page on your blog (e.g. <http://127.0.0.1:8080/manage>). Use username `admin` and password `admin` when logging in for the first time.
+1. Go to the management page on your blog (e.g. <http://127.0.0.1:8080/blog/manage>). Use username `admin` and password `admin` when logging in for the first time.
 
 2. Open the user management page and create a new user. Be sure to make the new user an administrator. The `admin` user will be disabled afterwards.
 
 3. Open the configuration management page and edit the `global` configuration. You can add categories by entering them into the first field, line by line. Category names must not contain spaces.
 
-4. Now you may edit the active configuration (`example`) and check the categories that should be included on the blog or change the blog name and description.
+4. Now you may edit the active configuration (`example`) and check the categories that should be included on the blog.
 
 
 Posting articles

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Embedding VibeLog into your own application
 		registerVibeLog(blogsettings, router);
 
 		router.get("*", serveStaticFiles("./public"));
-		
+
 		auto settings = new HttpServerSettings;
 		settings.port = 8080;
 		listenHttp(settings, router);
@@ -90,6 +90,14 @@ Setting everything up
 
 3. Open the configuration management page and edit the `global` configuration. You should add at least one category here. Each line in the text field represents one configuration and must not contain spaces.
 
-4. Now edit the blog's configuration (e.g. `vibelog`) and check all categories that should be listed on the blog.
+4. Now edit the active configuration (`example`) and check all categories that should be listed on the blog.
 
-5. Start posting new articles by choosing `New post` from the management page.
+
+Posting articles
+----------------
+
+1. Click on `New post` on the management page.
+
+2. Fill out the information, including any text filters (currently there's only Markdown, enabled by default).
+
+4. Click on `Create post` to post or the `Preview` checkbox to see what your post would look like.

--- a/public/scripts/vibelog-edit.js
+++ b/public/scripts/vibelog-edit.js
@@ -9,7 +9,7 @@ function previewUpdate()
 
 		if (filters != "")
 		{
-			$.get('/filter', {message: message.val(), filters: filters}, function(data){ preview.html(data) });
+			$.get(window.rootDir + 'filter', {message: message.val(), filters: filters}, function(data){ preview.html(data) });
 		}
 		else
 		{

--- a/public/scripts/vibelog-edit.js
+++ b/public/scripts/vibelog-edit.js
@@ -1,16 +1,28 @@
-function previewToggle()
+function previewUpdate()
 {
-	var enabled = $("#preview-checkbox").is(':checked');
-	if( enabled ){
-		var message = $("#message");
-		var preview = $("#message-preview");
+	var enabled = $('#preview-checkbox').is(':checked');
+	if( enabled )
+	{
+		var message = $('#message');
+		var preview = $('#message-preview');
+		var filters = $('#filters-field').val();
+
+		if (filters != "")
+		{
+			$.get('/filter', {message: message.val(), filters: filters}, function(data){ preview.html(data) });
+		}
+		else
+		{
+			preview.html(message.val());
+		}
+
 		preview.height(message.height());
 		message.hide();
 		preview.show();
-
-		$.post(window.rootDir+"markup", {message: message.val()}, function(data){ preview.html(data); prettyPrint(); });
-	} else {
-		$("#message").show();
-		$("#message-preview").hide();
+	}
+	else
+	{
+		$('#message').show();
+		$('#message-preview').hide();
 	}
 }

--- a/source/app.d
+++ b/source/app.d
@@ -13,7 +13,7 @@ shared static this()
 
 	auto blogSettings = new VibeLogSettings;
 	blogSettings.configName = "example";
-	blogSettings.siteURL = URL("http://localhost:8080/blog/sub/");
+	blogSettings.siteURL = URL("http://localhost:8080/blog/");
 	blogSettings.blogName = "VibeLog";
 	blogSettings.blogDescription = "Publishing software utilizing the vibe.d framework";
 
@@ -24,4 +24,7 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	listenHTTP(settings, router);
+
+	import vibe.core.log : logInfo;
+	logInfo("VibeLog is live at '" ~ blogSettings.rootDir ~ "'.");
 }

--- a/source/app.d
+++ b/source/app.d
@@ -11,14 +11,16 @@ shared static this()
 
 	auto router = new URLRouter;
 
-	auto blogsettings = new VibeLogSettings;
-	blogsettings.configName = "example";
-	blogsettings.siteURL = URL("http://localhost:8080/");
+	auto blogSettings = new VibeLogSettings;
+	blogSettings.configName = "example";
+	blogSettings.siteURL = URL("http://localhost:8080/blog/sub/");
+	blogSettings.blogName = "VibeLog";
+	blogSettings.blogDescription = "Publishing software utilizing the vibe.d framework";
 
-	auto ctrl = new VibeLogController(blogsettings);
+	auto ctrl = new VibeLogController(blogSettings);
 	router.registerVibeLogWeb(ctrl);
 	router.registerVibeLogWebAdmin(ctrl);
-	
+
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	listenHTTP(settings, router);

--- a/source/vibelog/config.d
+++ b/source/vibelog/config.d
@@ -6,6 +6,9 @@ final class Config {
 	BsonObjectID id;
 	string name;
 	string[] categories;
+	// Maybe blogName and blogDescription should be merged with feedTitle and feedDescription
+	string blogName = "VibeLog";
+	string blogDescription = "Publishing software utilizing the vibe.d framework";
 	string language = "en-us";
 	string copyrightString;
 	string mailServer;
@@ -36,7 +39,9 @@ final class Config {
 		ret.name = bson["name"].opt!string();
 		foreach( grp; cast(Bson[])bson["categories"] )
 			ret.categories ~= grp.opt!string();
-		ret.language = bson["language"].opt!string("en-us");
+		ret.blogName = bson["blogName"].opt!string(blogName.init);
+		ret.blogDescription = bson["blogDescription"].opt!string(blogDescription.init);
+		ret.language = bson["language"].opt!string(language.init);
 		ret.copyrightString = bson["copyrightString"].opt!string();
 		ret.mailServer = bson["mailServer"].opt!string();
 		ret.feedTitle = bson["feedTitle"].opt!string();
@@ -52,11 +57,20 @@ final class Config {
 		Bson[] bcategories;
 		foreach( grp; categories )
 			bcategories ~= Bson(grp);
+		
+		// Create a default category if none is specified
+		if(bcategories.length < 1)
+		{
+			bcategories ~= Bson("meta");
+		}
 
+		// Could use a switch here
 		Bson[string] ret;
 		ret["_id"] = Bson(id);
 		ret["name"] = Bson(name);
 		ret["categories"] = Bson(bcategories);
+		ret["blogName"] = Bson(blogName);
+		ret["blogDescription"] = Bson(blogDescription);
 		ret["language"] = Bson(language);
 		ret["copyrightString"] = Bson(copyrightString);
 		ret["mailServer"] = Bson(mailServer);

--- a/source/vibelog/config.d
+++ b/source/vibelog/config.d
@@ -6,9 +6,6 @@ final class Config {
 	BsonObjectID id;
 	string name;
 	string[] categories;
-	// Maybe blogName and blogDescription should be merged with feedTitle and feedDescription
-	string blogName = "VibeLog";
-	string blogDescription = "Publishing software utilizing the vibe.d framework";
 	string language = "en-us";
 	string copyrightString;
 	string mailServer;
@@ -39,8 +36,6 @@ final class Config {
 		ret.name = bson["name"].opt!string();
 		foreach( grp; cast(Bson[])bson["categories"] )
 			ret.categories ~= grp.opt!string();
-		ret.blogName = bson["blogName"].opt!string(blogName.init);
-		ret.blogDescription = bson["blogDescription"].opt!string(blogDescription.init);
 		ret.language = bson["language"].opt!string(language.init);
 		ret.copyrightString = bson["copyrightString"].opt!string();
 		ret.mailServer = bson["mailServer"].opt!string();
@@ -69,8 +64,6 @@ final class Config {
 		ret["_id"] = Bson(id);
 		ret["name"] = Bson(name);
 		ret["categories"] = Bson(bcategories);
-		ret["blogName"] = Bson(blogName);
-		ret["blogDescription"] = Bson(blogDescription);
 		ret["language"] = Bson(language);
 		ret["copyrightString"] = Bson(copyrightString);
 		ret["mailServer"] = Bson(mailServer);

--- a/source/vibelog/config.d
+++ b/source/vibelog/config.d
@@ -51,17 +51,17 @@ final class Config {
 		ret.feedImageUrl = bson["feedImageUrl"].opt!string();
 		return ret;
 	}
-	
+
 	Bson toBson()
 	const {
 		Bson[] bcategories;
 		foreach( grp; categories )
 			bcategories ~= Bson(grp);
-		
+
 		// Create a default category if none is specified
 		if(bcategories.length < 1)
 		{
-			bcategories ~= Bson("meta");
+			bcategories ~= Bson("general");
 		}
 
 		// Could use a switch here

--- a/source/vibelog/controller.d
+++ b/source/vibelog/controller.d
@@ -91,6 +91,17 @@ class VibeLogController {
 	{
 		return m_subPath ~ "?page=" ~ to!string(page+1);
 	}
+	
+	HeaderInfo getHeaderInfo()
+	{
+		return HeaderInfo(m_config.blogName, m_config.blogDescription);
+	}
+}
+
+struct HeaderInfo
+{
+	string blogName;
+	string blogDescription;
 }
 
 struct PostListInfo {

--- a/source/vibelog/controller.d
+++ b/source/vibelog/controller.d
@@ -18,7 +18,6 @@ class VibeLogController {
 	{
 		m_settings = settings;
 		m_db = createDBController(settings);
-		m_subPath = settings.siteURL.path.toString();
 
 		try m_config = m_db.getConfig(settings.configName, true);
 		catch( Exception e ){

--- a/source/vibelog/controller.d
+++ b/source/vibelog/controller.d
@@ -11,7 +11,6 @@ class VibeLogController {
 	private {
 		DBController m_db;
 		VibeLogSettings m_settings;
-		string m_subPath;
 		Config m_config;
 	}
 
@@ -20,7 +19,7 @@ class VibeLogController {
 		m_settings = settings;
 		m_db = createDBController(settings);
 		m_subPath = settings.siteURL.path.toString();
-	
+
 		try m_config = m_db.getConfig(settings.configName, true);
 		catch( Exception e ){
 			import vibe.core.log;
@@ -37,7 +36,6 @@ class VibeLogController {
 	PostListInfo getPostListInfo(int page = 0, int page_size = 0)
 	{
 		PostListInfo info;
-		info.rootDir = m_subPath; // TODO: use relative path
 		info.users = m_db.getAllUsers();
 		info.settings = m_settings;
 		info.pageCount = getPageCount(page_size);
@@ -46,7 +44,7 @@ class VibeLogController {
 		foreach( p; info.posts ) info.commentCount ~= m_db.getCommentCount(p.id);
 		info.recentPosts = getRecentPosts();
 		return info;
-	}	
+	}
 
 	int getPageCount(int page_size = 0)
 	{
@@ -89,23 +87,11 @@ class VibeLogController {
 
 	string getShowPagePath(int page)
 	{
-		return m_subPath ~ "?page=" ~ to!string(page+1);
+		return m_settings.rootDir ~ "?page=" ~ to!string(page+1);
 	}
-	
-	HeaderInfo getHeaderInfo()
-	{
-		return HeaderInfo(m_config.blogName, m_config.blogDescription);
-	}
-}
-
-struct HeaderInfo
-{
-	string blogName;
-	string blogDescription;
 }
 
 struct PostListInfo {
-	string rootDir;
 	User[string] users;
 	VibeLogSettings settings;
 	int pageNumber = 0;

--- a/source/vibelog/post.d
+++ b/source/vibelog/post.d
@@ -23,9 +23,10 @@ final class Post {
 	string category; // can be hierarchical using dotted.syntax.format
 	SysTime date;
 	string header;
+	string headerImage;
 	string subHeader;
 	string content;
-	string headerImage;
+	string[] filters;
 	string[] tags;
 	string[] trackbacks;
 
@@ -47,20 +48,22 @@ final class Post {
 		ret.author = cast(string)bson["author"];
 		ret.category = cast(string)bson["category"];
 		ret.date = SysTime.fromISOExtString(cast(string)bson["date"]);
+		ret.headerImage = cast(string)bson["headerImage"];
 		ret.header = cast(string)bson["header"];
 		ret.subHeader = cast(string)bson["subHeader"];
-		ret.headerImage = cast(string)bson["headerImage"];
 		ret.content = cast(string)bson["content"];
+
+		foreach( f; cast(Bson[])bson["filters"] )
+			ret.filters ~= cast(string)f;
+
 		foreach( t; cast(Bson[])bson["tags"] )
 			ret.tags ~= cast(string)t;
+
 		return ret;
 	}
 
 	Bson toBson()
 	const {
-		Bson[] btags;
-		foreach( t; tags )
-			btags ~= Bson(t);
 
 		Bson[string] ret;
 		ret["_id"] = Bson(id);
@@ -70,38 +73,58 @@ final class Post {
 		ret["author"] = Bson(author);
 		ret["category"] = Bson(category);
 		ret["date"] = Bson(date.toISOExtString());
+		ret["headerImage"] = Bson(headerImage);
 		ret["header"] = Bson(header);
 		ret["subHeader"] = Bson(subHeader);
-		ret["headerImage"] = Bson(headerImage);
 		ret["content"] = Bson(content);
-		ret["tags"] = Bson(btags);
+
+		import std.algorithm : map;
+		import std.array : array;
+		ret["filters"] = Bson(filters.map!Bson.array);
+		ret["tags"] = Bson(tags.map!Bson.array);
 
 		return Bson(ret);
 	}
 
 	string renderSubHeaderAsHtml(VibeLogSettings settings)
 	const {
-		auto ret = appender!string();
-		filterMarkdown(ret, subHeader, settings.markdownSettings);
-		return ret.data;
+		import std.algorithm : canFind;
+		if (filters.canFind("markdown"))
+		{
+			auto ret = appender!string();
+			filterMarkdown(ret, subHeader, settings.markdownSettings);
+			return ret.data;
+		}
+		else
+		{
+			return subHeader;
+		}
 	}
 
-	string renderContentAsHtml(VibeLogSettings settings, string page_path, int header_level_nesting = 0)
+	string renderContentAsHtml(VibeLogSettings settings, string page_path = "", int header_level_nesting = 0)
 	const {
-		import std.algorithm : startsWith;
-		scope ms = new MarkdownSettings;
-		ms.flags = settings.markdownSettings.flags;
-		ms.headingBaseLevel = settings.markdownSettings.headingBaseLevel + header_level_nesting;
-		ms.urlFilter = (lnk, is_image) {
-			if (lnk.startsWith("http://") || lnk.startsWith("https://"))
-				return lnk;
-			auto pp = Path(page_path);
-			if (!pp.endsWithSlash)
-				pp = pp[0 .. $-1];
-			return (settings.siteURL.path~("posts/"~slug~"/"~lnk)).relativeTo(pp).toString();
-		};
 
-		auto html = filterMarkdown(content, ms);
+		import std.algorithm : canFind;
+		if (filters.canFind("markdown"))
+		{
+			scope ms = new MarkdownSettings;
+			ms.flags = settings.markdownSettings.flags;
+			ms.headingBaseLevel = settings.markdownSettings.headingBaseLevel + header_level_nesting;
+			if (page_path != "")
+			{
+				ms.urlFilter = (lnk, is_image) {
+					import std.algorithm : startsWith;
+					if (lnk.startsWith("http://") || lnk.startsWith("https://"))
+						return lnk;
+					auto pp = Path(page_path);
+					if (!pp.endsWithSlash)
+						pp = pp[0 .. $-1];
+					return (settings.siteURL.path~("posts/"~slug~"/"~lnk)).relativeTo(pp).toString();
+				};
+			}
+			settings.textFilters ~= (string content) { return filterMarkdown(content, ms); };
+		}
+		string html = content;
 		foreach (flt; settings.textFilters)
 			html = flt(html);
 		return html;

--- a/source/vibelog/settings.d
+++ b/source/vibelog/settings.d
@@ -13,7 +13,7 @@ final class VibeLogSettings {
 	URL siteURL = URL.parse("http://localhost:8080/");
 	deprecated("Use siteURL instead.") alias siteUrl = siteURL;
 	string adminPrefix = "manage/";
-	string function(string)[] textFilters;
+	string delegate(string) @safe [] textFilters;
 	MarkdownSettings markdownSettings;
 
 	this()

--- a/source/vibelog/settings.d
+++ b/source/vibelog/settings.d
@@ -7,6 +7,8 @@ import vibe.textfilter.markdown;
 final class VibeLogSettings {
 	string databaseURL = "mongodb://localhost/vibelog";
 	string configName = "global";
+	string blogName = "VibeLog";
+	string blogDescription = "Publishing software utilizing the vibe.d framework";
 	int postsPerPage = 4;
 	int maxRecentPosts = 20;
 	bool showFullPostsInPostList = true;
@@ -20,5 +22,13 @@ final class VibeLogSettings {
 	{
 		markdownSettings = new MarkdownSettings;
 		markdownSettings.flags = MarkdownFlags.backtickCodeBlocks;
+	}
+
+	@property
+	{
+		string rootDir()
+		{
+			return siteURL.path.toString();
+		}
 	}
 }

--- a/source/vibelog/view.d
+++ b/source/vibelog/view.d
@@ -1,0 +1,12 @@
+module vibelog.view;
+
+class VibeLogView
+{
+	import vibelog.settings : VibeLogSettings;
+	VibeLogSettings settings;
+
+	this(VibeLogSettings settings)
+	{
+		this.settings = settings;
+	}
+}

--- a/source/vibelog/web.d
+++ b/source/vibelog/web.d
@@ -25,7 +25,7 @@ import std.string;
 
 void registerVibeLogWeb(URLRouter router, VibeLogController controller)
 {
-	auto sub_path = controller.settings.siteURL.path.toString();
+	string sub_path = controller.settings.rootDir;
 	assert(sub_path.endsWith("/"), "Blog site URL must end with '/'.");
 
 	if (sub_path.length > 1) router.get(sub_path[0 .. $-1], staticRedirect(sub_path));
@@ -78,7 +78,7 @@ private final class VibeLogWeb {
 		catch(Exception e){ return; } // -> gives 404 error
 		info.comments = m_ctrl.db.getComments(info.post.id);
 		info.recentPosts = m_ctrl.getRecentPosts();
-		info.refPath = "/posts/"~_postname;
+		info.refPath = m_settings.rootDir~"posts/"~_postname;
 		info.error = _error;
 
 		render!("vibelog.post.dt", info);

--- a/source/vibelog/webadmin.d
+++ b/source/vibelog/webadmin.d
@@ -365,7 +365,7 @@ private final class VibeLogWebAdmin {
 			enforce(_postname == p.name, "URL does not match the edited post!");
 		} else {
 			p = new Post;
-			p.category = "meta";
+			p.category = "general";
 			p.date = Clock.currTime().toUTC();
 		}
 		enforce(_auth.loginUser.mayPostInCategory(category), "You are now allowed to post in the '"~category~"' category.");

--- a/views/layout.admin.dt
+++ b/views/layout.admin.dt
@@ -1,9 +1,0 @@
-!!! 5
-html
-    head
-        block title
-        link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/common.css")
-        link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/menu.css")
-        title #{title} - VibeLog
-    body
-        block body

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -1,12 +1,12 @@
 !!! 5
 html
 	head
+		- string sep = " - ";
 		block title
+		title= title ~ sep ~ info.header.blogName
 		link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/common.css")
-		title #{title} - VibeLog
+		block layout.head
 	body
 		header
-			h1 VibeLog
-			h2 This is the super duper blog!
-
-		block body
+			block layout.header
+		block layout.content

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -3,8 +3,8 @@ html
 	head
 		- string sep = " - ";
 		block title
-		title= title ~ sep ~ info.header.blogName
-		link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/common.css")
+		title= title ~ sep ~ info.settings.blogName
+		link(rel="stylesheet", type="text/css", href="#{info.settings.rootDir}styles/common.css")
 		block layout.head
 	body
 		header

--- a/views/vibelog.admin.editconfig.dt
+++ b/views/vibelog.admin.editconfig.dt
@@ -2,7 +2,7 @@ extends vibelog.admin.layout
 
 block title
 	- import std.array;
-	- auto title = "Edit configuration '"~config.name~"'";
+	- auto title = "Edit configuration '"~info.config.name~"'";
 
 block vibelog-localnav
 	ul.admin-local-nav
@@ -11,16 +11,16 @@ block vibelog-localnav
 
 block vibelog-content
 	form(action="./", method="POST")
-		- if( config.name == "global" )
+		- if( info.config.name == "global" )
 			p
 				label(for="categories") Categories
 				br
-				textarea(name="categories", rows="10", cols="40")= join(config.categories, "\n")
+				textarea(name="categories", rows="10", cols="40")= join(info.config.categories, "\n")
 		- else
 			p Categories
 			p
-				- foreach( grp; globalConfig.categories )
-					- if( config.hasCategory(grp) )
+				- foreach( grp; info.globalConfig.categories )
+					- if( info.config.hasCategory(grp) )
 						input(type="checkbox", name="category_#{grp}", value="1", checked)
 					- else
 						input(type="checkbox", name="category_#{grp}", value="1")
@@ -28,31 +28,39 @@ block vibelog-content
 					br
 
 		p
+			label(for="blogName") Blog name
+			input(type="text", name="blogName", value="#{info.config.blogName}")
+
+		p
+			label(for="blogDescription") Blog description
+			input(type="text", name="blogDescription", value="#{info.config.blogDescription}")
+		
+		p
 			label(for="language") Language
-			input(type="text", name="language", value="#{config.language}")
+			input(type="text", name="language", value="#{info.config.language}")
 
 		p
 			label(for="copyrightString") Copyright String
-			input(type="text", name="copyrightString", value="#{config.copyrightString}")
+			input(type="text", name="copyrightString", value="#{info.config.copyrightString}")
 
 		p
 			label(for="feedTitle") Feed title
-			input(type="text", name="feedTitle", value="#{config.feedTitle}")
+			input(type="text", name="feedTitle", value="#{info.config.feedTitle}")
 
 		p
 			label(for="feedLink") Feed link
-			input(type="url", name="feedLink", value="#{config.feedLink}")
+			input(type="url", name="feedLink", value="#{info.config.feedLink}")
 
 		p
 			label(for="feedDescription") Feed description
-			input(type="text", name="feedDescription", value="#{config.feedDescription}")
+			input(type="text", name="feedDescription", value="#{info.config.feedDescription}")
 
 		p
 			label(for="feedImageTitle") Feed image title
-			input(type="text", name="feedImageTitle", value="#{config.feedImageTitle}")
+			input(type="text", name="feedImageTitle", value="#{info.config.feedImageTitle}")
 
 		p
 			label(for="feedImageUrl") Feed image URL
-			input(type="url", name="feedImageUrl", value="#{config.feedImageUrl}")
+			input(type="url", name="feedImageUrl", value="#{info.config.feedImageUrl}")
 
 		input(type="submit", value="Apply changes")

--- a/views/vibelog.admin.editconfig.dt
+++ b/views/vibelog.admin.editconfig.dt
@@ -28,14 +28,6 @@ block vibelog-content
 					br
 
 		p
-			label(for="blogName") Blog name
-			input(type="text", name="blogName", value="#{info.config.blogName}")
-
-		p
-			label(for="blogDescription") Blog description
-			input(type="text", name="blogDescription", value="#{info.config.blogDescription}")
-		
-		p
 			label(for="language") Language
 			input(type="text", name="language", value="#{info.config.language}")
 

--- a/views/vibelog.admin.editconfiglist.dt
+++ b/views/vibelog.admin.editconfiglist.dt
@@ -16,10 +16,10 @@ block vibelog-content
 			th Name
 			th Edit
 			th Delete
-		- foreach (cfg; configs)
+		- foreach (cfg; info.configs)
 			tr
 				td= cfg.name
-					- if (cfg.name == activeConfig)
+					- if (cfg.name == info.activeConfig)
 						| (active)
 				td
 					form(action="#{cfg.name}/", method="GET")

--- a/views/vibelog.admin.editconfiglist.dt
+++ b/views/vibelog.admin.editconfiglist.dt
@@ -10,7 +10,7 @@ block vibelog-localnav
 
 block vibelog-content
 	- import std.datetime;
-	
+
 	table(width="100%")
 		tr
 			th Name
@@ -19,7 +19,7 @@ block vibelog-content
 		- foreach (cfg; info.configs)
 			tr
 				td= cfg.name
-					- if (cfg.name == info.activeConfig)
+					- if (cfg.name == info.activeConfigName)
 						| (active)
 				td
 					form(action="#{cfg.name}/", method="GET")

--- a/views/vibelog.admin.editpost.dt
+++ b/views/vibelog.admin.editpost.dt
@@ -4,10 +4,10 @@ block title
 	- import std.datetime;
 
 	- auto title = (info.post ? "Modify" : "Add new") ~ " blog post";
-	script(type="text/javascript", src="#{req.rootDir}scripts/jquery.js")
-	script(type="text/javascript", src="#{req.rootDir}scripts/vibelog-edit.js")
+	script(type="text/javascript", src="#{info.settings.rootDir}scripts/jquery.js")
+	script(type="text/javascript", src="#{info.settings.rootDir}scripts/vibelog-edit.js")
 	script(type="text/javascript").
-		window.rootDir = "#{info.ctx.settings.siteURL}";
+		window.rootDir = "#{info.settings.rootDir}";
 
 block vibelog-localnav
 	ul.admin-local-nav

--- a/views/vibelog.admin.editpost.dt
+++ b/views/vibelog.admin.editpost.dt
@@ -3,28 +3,28 @@ extends vibelog.admin.layout
 block title
 	- import std.datetime;
 
-	- auto title = (post ? "Modify" : "Add new") ~ " blog post";
+	- auto title = (info.post ? "Modify" : "Add new") ~ " blog post";
 	script(type="text/javascript", src="#{req.rootDir}scripts/jquery.js")
 	script(type="text/javascript", src="#{req.rootDir}scripts/vibelog-edit.js")
 	script(type="text/javascript").
-		window.rootDir = "#{ctx.settings.siteURL}";
+		window.rootDir = "#{info.ctx.settings.siteURL}";
 
 block vibelog-localnav
 	ul.admin-local-nav
 		li
-			a(href='#{post?"../":"./"}') Cancel
+			a(href='#{info.post ? "../" : "./"}') Cancel
 
 block vibelog-content
-	- if (!post || post.author == ctx.loginUser.username || ctx.loginUser.isPostAdmin())
-		form(action='#{post?"./":"make_post"}', method="POST")
-			input(type="hidden", name="id", value="#{post ? post.id.toString() : null}")
+	- if (!info.post || info.post.author == info.ctx.loginUser.username || info.ctx.loginUser.isPostAdmin())
+		form(action='#{info.post ? "./" : "make_post"}', method="POST")
+			input(type="hidden", name="id", value="#{info.post ? info.post.id.toString() : null}")
 			table.blind
 				col.caption
 				tr
 					td
 						label(for="isPublic") Public
 					td
-						- if( post && post.isPublic )
+						- if( info.post && info.post.isPublic )
 							input#isPublic.checkbox(type="checkbox", name="isPublic", value="yes", checked)
 						- else
 							input#isPublic.checkbox(type="checkbox", name="isPublic", value="yes")
@@ -32,33 +32,33 @@ block vibelog-content
 					td
 						label(for="commentsAllowed") Comments allowed
 					td
-						- if( !post || post.commentsAllowed )
+						- if( !info.post || info.post.commentsAllowed )
 							input#commentsAllowed.checkbox(type="checkbox", name="commentsAllowed", value="yes", checked)
 						- else
 							input#commentsAllowed.checkbox(type="checkbox", name="commentsAllowed", value="yes")
 				tr
-					- if (ctx.loginUser.isPostAdmin())
+					- if (info.ctx.loginUser.isPostAdmin())
 						td
 							label(for="author") Author
 						td
 							select#author(name="author", size="1")
-								- foreach (usr; ctx.users)
-									- if (usr.username == (post ? post.author : ctx.loginUser.username))
+								- foreach (usr; info.ctx.users)
+									- if (usr.username == (info.post ? info.post.author : info.ctx.loginUser.username))
 										option(value="#{usr.username}", selected) #{usr.name} (#{usr.username})
 									- else
 										option(value="#{usr.username}") #{usr.name} (#{usr.username})
 					- else
 						td Author
-						td #{ctx.loginUser.name} (#{ctx.loginUser.username})
-							input(type="hidden", name="author", value="#{ctx.loginUser.username}")
+						td #{info.ctx.loginUser.name} (#{info.ctx.loginUser.username})
+							input(type="hidden", name="author", value="#{info.ctx.loginUser.username}")
 				tr
 					td
 						label(for="category") Category
 					td
 						select#category(name="category", size="1")
-							- foreach (cat; globalConfig.categories)
-								- if (ctx.loginUser.isPostAdmin() || ctx.loginUser.mayPostInCategory(cat))
-									- if (post && cat == post.category)
+							- foreach (cat; info.globalConfig.categories)
+								- if (info.ctx.loginUser.isPostAdmin() || info.ctx.loginUser.mayPostInCategory(cat))
+									- if (info.post && cat == info.post.category)
 										option(value="#{cat}", selected)= cat
 									- else
 										option(value="#{cat}")= cat
@@ -66,17 +66,17 @@ block vibelog-content
 					td
 						label(for="date") Date
 					td
-						input#date(type="text", name="date", value="#{post ? post.date.toSimpleString() : Clock.currTime().toSimpleString()}")
+						input#date(type="text", name="date", value="#{info.post ? info.post.date.toSimpleString() : Clock.currTime().toSimpleString()}")
 				tr
 					td
 						label(for="slug") Post slug
 					td
-						input#slug(type="text", name="slug", value="#{post ? post.slug : null}")
+						input#slug(type="text", name="slug", value="#{info.post ? info.post.slug : null}")
 				tr
 					td
 						label(for="headerImage-field") Header image
 					td
-						input#headerImage-field(type="text", name="headerImage", value="#{post ? post.headerImage : null}")
+						input#headerImage-field(type="text", name="headerImage", value="#{info.post ? info.post.headerImage : null}")
 				tr
 					td(colspan=2)
 						hr
@@ -84,32 +84,35 @@ block vibelog-content
 					td
 						label(for="header-field") Heading
 					td
-						input#header-field(type="text", name="header", value="#{post ? post.header : null}")
+						input#header-field(type="text", name="header", value="#{info.post ? info.post.header : null}")
 				tr
 					td
 						label(for="subHeader") Sub-Heading
 					td
-						textarea#subHeader(rows=3, name="subHeader")= post ? post.subHeader : null
+						textarea#subHeader(rows=3, name="subHeader")= info.post ? info.post.subHeader : null
 				tr
 					td Article text
 						p
-							input#preview-checkbox.checkbox(type="checkbox", onchange="previewToggle()", style="width: auto;")
+							input#preview-checkbox.checkbox(type="checkbox", onchange="previewUpdate();", style="width: auto;", autocomplete="off")
 							label(for="preview-checkbox") Preview
+						p
+							label(for="filters-field") Filters
+							input#filters-field(type="text", name="filters", onchange="previewUpdate();", style="width: auto;", autocomplete="off", value='#{info.post ? info.post.filters.join(" ") : "markdown"}')
 					td
 						#message-area
-							textarea#message(name="content", rows="18")= post ? post.content : null
+							textarea#message(name="content", rows="18")= info.post ? info.post.content : null
 							#message-preview(style="display: none;")
-			input(type="submit", value='#{post?"Apply changes":"Create post!"}')
+			input(type="submit", value='#{info.post ? "Apply changes" : "Create post!"}')
 
-		- if (post)
+		- if (info.post)
 			h2 Files
 
-			- if (files.length)
+			- if (info.files.length)
 				table
 					tr
 						th Name
 						th Action
-					- foreach (f; files)
+					- foreach (f; info.files)
 						tr
 							td= f
 							td
@@ -123,7 +126,7 @@ block vibelog-content
 				input(type="file", name="files", multiple)
 				button(type="submit") Upload
 
-		- if( comments.length )
+		- if( info.comments.length )
 			h2 Comments
 
 			table
@@ -135,7 +138,7 @@ block vibelog-content
 					th Content
 					th IP
 					th Action
-				- foreach( c; comments )
+				- foreach( c; info.comments )
 					tr(class='#{c.isPublic ? "" : "inactive"}')
 						- auto d = c.date; d.fracSec = FracSec.from!"usecs"(0);
 						td= d.toSimpleString()
@@ -146,15 +149,15 @@ block vibelog-content
 						td= c.authorIP
 						td
 							form(action="set_comment_public", method="POST")
-								input(type="hidden", name="public", value="#{c.isPublic ? 0 : 1}")
+								input(type="hidden", name="public_", value='#{c.isPublic ? false : true}')
 								input(type="hidden", name="id", value="#{c.id}")
 								button(type="submit")= c.isPublic ? "Hide" : "Show"
 	- else
-		p.error You are not the author of this post and are not authorized to change it.
-		
-		p Public: #{post.isPublic ? "yes" : "no"}
-		p Author: #{post.author}
-		p Heading: #{post.header}
-		p Sub-Heading: #{post.subHeader}
+		p.error You are not the author of this post and/or are not authorized to change it.
+
+		p Public: #{info.post.isPublic ? "yes" : "no"}
+		p Author: #{info.post.author}
+		p Heading: #{info.post.header}
+		p Sub-Heading: #{info.post.subHeader}
 		p Content:
-		pre= post.content
+		pre= info.post.content

--- a/views/vibelog.admin.editpostslist.dt
+++ b/views/vibelog.admin.editpostslist.dt
@@ -23,8 +23,8 @@ block vibelog-content
 			th View
 			th Edit
 			th Delete
-		- foreach (post; posts)
-			- if (ctx.loginUser.isPostAdmin() || ctx.loginUser.username == post.author)
+		- foreach (post; info.posts)
+			- if (info.ctx.loginUser.isPostAdmin() || info.ctx.loginUser.username == post.author)
 				tr
 					td= (cast(Date)post.date).toSimpleString()
 					td= post.isPublic ? "yes" : ""
@@ -32,7 +32,7 @@ block vibelog-content
 					td= post.author
 					td= post.category
 					td
-						form(action="#{ctx.settings.siteURL}posts/#{post.name}", method="GET")
+						form(action="#{info.ctx.settings.siteURL}posts/#{post.name}", method="GET")
 							input(type="submit", value="view")
 					td
 						form(action="#{post.name}/", method="GET")

--- a/views/vibelog.admin.edituser.dt
+++ b/views/vibelog.admin.edituser.dt
@@ -1,7 +1,7 @@
 extends vibelog.admin.layout
 
 block title
-	- auto title = "Edit user '"~user.username~"'";
+	- auto title = "Edit user '"~info.user.username~"'";
 
 block vibelog-localnav
 	ul.admin-local-nav
@@ -12,17 +12,17 @@ block vibelog-content
 	- import std.datetime;
 	
 	form(action="./", method="POST")
-		input(type="hidden", name="id", value="#{user._id.toString()}")
+		input(type="hidden", name="id", value="#{info.user._id.toString()}")
 		p
 			label(for="username") Username
-			input(type="text", name="username", value="#{user.username}")
+			input(type="text", name="username", value="#{info.user.username}")
 		p
 			label(for="name") Full name
-			input(type="text", name="name", value="#{user.name}")
+			input(type="text", name="name", value="#{info.user.name}")
 		p
 			label(for="email") Email
-			input(type="email", name="email", value="#{user.email}")
-		- if (!ctx.loginUser.isUserAdmin())
+			input(type="email", name="email", value="#{info.user.email}")
+		- if (!info.ctx.loginUser.isUserAdmin())
 			p
 				label(for="oldPassword") Current Password
 				input(type="password", name="oldPassword", value="")
@@ -32,11 +32,11 @@ block vibelog-content
 		p
 			label(for="passwordConfirmation") Confim new password
 			input(type="password", name="passwordConfirmation", value="")
-		- if (ctx.loginUser.isUserAdmin())
+		- if (info.ctx.loginUser.isUserAdmin())
 			p Groups:
 			p
-				- foreach( grp; globalConfig.groups )
-					- if( user.inGroup(grp) )
+				- foreach( grp; info.globalConfig.groups )
+					- if( info.user.inGroup(grp) )
 						input.checkbox(type="checkbox", name="group_#{grp}", value="1", checked)
 					- else
 						input.checkbox(type="checkbox", name="group_#{grp}", value="1")
@@ -44,8 +44,8 @@ block vibelog-content
 					br
 			p Allowed categories:
 			p
-				- foreach( grp; globalConfig.categories )
-					- if( user.mayPostInCategory(grp) )
+				- foreach( grp; info.globalConfig.categories )
+					- if( info.user.mayPostInCategory(grp) )
 						input.checkbox(type="checkbox", name="category_#{grp}", value="1", checked)
 					- else
 						input.checkbox(type="checkbox", name="category_#{grp}", value="1")

--- a/views/vibelog.admin.edituserlist.dt
+++ b/views/vibelog.admin.edituserlist.dt
@@ -16,14 +16,14 @@ block vibelog-content
 			input(type="text", name="username")
 			input(type="submit", value="create")
 
-	- if (ctx.loginUser.isUserAdmin())
+	- if (info.ctx.loginUser.isUserAdmin())
 		table(width="100%")
 			tr
 				th Username
 				th Full name
 				th Edit
 				th Delete
-			- foreach (usr; ctx.users)
+			- foreach (usr; info.ctx.users)
 				tr
 					td= usr.username
 					td= usr.name
@@ -35,5 +35,5 @@ block vibelog-content
 							input(type="submit", value="delete")
 	- else
 		p Sorry, you are not authorized to edit users. You can, however,
-			a(href="#{ctx.loginUser.username}/") edit your own account
+			a(href="#{info.ctx.loginUser.username}/") edit your own account
 			|.

--- a/views/vibelog.admin.inc.nav.dt
+++ b/views/vibelog.admin.inc.nav.dt
@@ -1,6 +1,6 @@
 - auto tmp = Path(req.path);
 - if (!tmp.endsWithSlash) tmp = tmp[0 .. $-1];
-- tmp = ctx.rootPath.relativeTo(tmp);
+- tmp = info.ctx.rootPath.relativeTo(tmp);
 - auto root_dir = tmp.toString();
 - if (!root_dir.length) root_dir = "./";
 
@@ -11,12 +11,12 @@ ul.headerMenu.admin-global-nav
         a(href="#{root_dir}make_post") New post
     li
         a(href="#{root_dir}posts/") Manage posts
-    - if (ctx.loginUser.isConfigAdmin())
+    - if (info.ctx.loginUser.isConfigAdmin())
         li
             a(href="#{root_dir}configs/") Manage configurations
-    - if (ctx.loginUser.isUserAdmin())
+    - if (info.ctx.loginUser.isUserAdmin())
         li
             a(href="#{root_dir}users/") Manage users
     - else
         li
-            a(href="#{root_dir}users/#{ctx.loginUser.username}/") Manage account
+            a(href="#{root_dir}users/#{info.ctx.loginUser.username}/") Manage account

--- a/views/vibelog.admin.layout.dt
+++ b/views/vibelog.admin.layout.dt
@@ -1,6 +1,6 @@
 extends vibelog.layout
 block vibelog.layout.head
-	link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/menu.css")
+	link(rel="stylesheet", type="text/css", href="#{info.settings.rootDir}styles/menu.css")
 	block vibelog.admin.layout.head
 block vibelog.layout.header
 	div#menuContainer

--- a/views/vibelog.admin.layout.dt
+++ b/views/vibelog.admin.layout.dt
@@ -1,13 +1,13 @@
-extends layout.admin
-
-block body
-	header
-		h1= title
-		h2 This is the super duper blog
-
-		div#menuContainer
-			include vibelog.admin.inc.nav
-
+extends vibelog.layout
+block vibelog.layout.head
+	link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/menu.css")
+	block vibelog.admin.layout.head
+block vibelog.layout.header
+	div#menuContainer
+		include vibelog.admin.inc.nav
+	block vibelog.admin.layout.header
+block vibelog.layout.content
 	#vibelogContent
 		block vibelog-localnav
 		block vibelog-content
+	block vibelog.admin.layout.content

--- a/views/vibelog.blocks.dt
+++ b/views/vibelog.blocks.dt
@@ -1,6 +1,6 @@
 extends vibelog.layout
 
-block body
+block vibelog.layout.content
 	#vibelogRecentList
 		block vibelog-recent-list
 

--- a/views/vibelog.inc.header.dt
+++ b/views/vibelog.inc.header.dt
@@ -1,2 +1,2 @@
-h1= info.header.blogName
-h2= info.header.blogDescription
+h1= info.settings.blogName
+h2= info.settings.blogDescription

--- a/views/vibelog.inc.header.dt
+++ b/views/vibelog.inc.header.dt
@@ -1,0 +1,2 @@
+h1= info.header.blogName
+h2= info.header.blogDescription

--- a/views/vibelog.inc.headlinelist.dt
+++ b/views/vibelog.inc.headlinelist.dt
@@ -10,7 +10,7 @@
 					.blogPostDate= toRFC822DateString(post.date)
 				- auto hlvl = config.headerLevel;
 				- if (config.headerLinks)
-					|<h#{hlvl}><a href="#{info.rootDir}posts/#{post.name}">#{post.header}</a></h#{hlvl}>
+					|<h#{hlvl}><a href="#{info.settings.rootDir}posts/#{post.name}">#{post.header}</a></h#{hlvl}>
 				- else
 					|<h#{hlvl}>#{post.header}</h#{hlvl}>
 				- if (!config.dateFirst)
@@ -22,4 +22,4 @@
 						.blogPostHeaderText(class='#{post.headerImage.length ? "with-image" : "without-image"}')
 							|#{post.subHeader}
 				- if (config.footerLinks)
-					a(href="#{info.rootDir}posts/#{post.name}")& Read more&hellip;
+					a(href="#{info.settings.rootDir}posts/#{post.name}")& Read more&hellip;

--- a/views/vibelog.inc.postlist.dt
+++ b/views/vibelog.inc.postlist.dt
@@ -19,4 +19,4 @@
 				ul
 					- foreach( p; yr )
 						li
-							a(href="#{info.rootDir}posts/#{p.name}")= p.header
+							a(href="#{info.settings.rootDir}posts/#{p.name}")= p.header

--- a/views/vibelog.layout.dt
+++ b/views/vibelog.layout.dt
@@ -1,1 +1,8 @@
 extends layout
+block layout.head
+	block vibelog.layout.head
+block layout.header
+	include vibelog.inc.header
+	block vibelog.layout.header
+block layout.content
+	block vibelog.layout.content

--- a/views/vibelog.post.dt
+++ b/views/vibelog.post.dt
@@ -24,24 +24,6 @@ block vibelog-content
 					p Posted at #{toRFC822TimeString(info.post.date)} by #{info.post.author in info.users ? info.users[info.post.author].name : info.post.author}
 
 			section.comments
-				- if( info.comments.length )
-					h2#comments Comments
-					
-					- import vibe.textfilter.html;
-					- foreach( c; info.comments )
-						.comment
-							.commentHeader
-								- if( c.authorName.length > 0 && c.authorHomepage.length > 0 )
-									a(href="#{c.authorHomepage}")= c.authorName
-								- else if( c.authorName.length > 0 )
-									| #{c.authorName}
-								- else
-									| anonymous
-								- if( c.authorMail.length > 0 )
-									|!= "&lt;" ~ htmlAllEscape(c.authorMail) ~ "&gt;"
-								| on #{toRFC822DateString(c.date)}, #{toRFC822TimeString(c.date)}:
-							.commentContent= c.content
-				
 				- if( info.post.commentsAllowed )
 					h2 Post a comment
 					form(action="#{info.post.name}/post_comment", method="POST")
@@ -67,6 +49,24 @@ block vibelog-content
 									input(type="submit", value="Post")
 				- else
 					p.error Commenting is currently disabled for this article.
+
+				- if( info.comments.length )
+					h2#comments Comments
+
+					- import vibe.textfilter.html;
+					- foreach( c; info.comments )
+						.comment
+							.commentHeader
+								- if( c.authorName.length > 0 && c.authorHomepage.length > 0 )
+									a(href="#{c.authorHomepage}")= c.authorName
+								- else if( c.authorName.length > 0 )
+									| #{c.authorName}
+								- else
+									| anonymous
+								- if( c.authorMail.length > 0 )
+									|!= "&lt;" ~ htmlAllEscape(c.authorMail) ~ "&gt;"
+								| on #{toRFC822DateString(c.date)}, #{toRFC822TimeString(c.date)}:
+							.commentContent= c.content
 
 block vibelog-recent-list
 	include vibelog.inc.postlist

--- a/views/vibelog.post.dt
+++ b/views/vibelog.post.dt
@@ -26,7 +26,7 @@ block vibelog-content
 			section.comments
 				- if( info.post.commentsAllowed )
 					h2 Post a comment
-					form(action="#{info.post.name}/post_comment", method="POST")
+					form(action="#{info.refPath}/post_comment", method="POST")
 						table.blind.comment-form
 							col.caption
 							tr
@@ -49,6 +49,8 @@ block vibelog-content
 									input(type="submit", value="Post")
 				- else
 					p.error Commenting is currently disabled for this article.
+				- if( info.error.length > 0 )
+					p.error= info.error
 
 				- if( info.comments.length )
 					h2#comments Comments

--- a/views/vibelog.postlist.dt
+++ b/views/vibelog.postlist.dt
@@ -1,8 +1,7 @@
 extends vibelog.blocks
 
 block title
-	- import vibe.inet.message;
-	- auto title = "Blog";
+	- auto title = "All posts";
 
 block vibelog-content
 	#vibelogContent
@@ -17,12 +16,14 @@ block vibelog-content
 								- if( post.headerImage.length )
 									img.headerImage(alt="Header image", src="#{post.headerImage}")
 								.blogPostHeaderText(class='#{post.headerImage.length ? "with-image" : "without-image"}')
+									- import vibe.inet.message : toRFC822DateString;
 									span.blogPostDate= toRFC822DateString(post.date)
 									|#{post.subHeader}
 						- if (info.settings.showFullPostsInPostList)
 							.blogPostContent(class='#{post.headerImage.length ? "with-image" : "without-image"}')
 								!= post.renderContentAsHtml(info.settings, info.refPath, 2)
 							footer
+								- import vibe.inet.message : toRFC822TimeString;
 								| Posted at #{toRFC822TimeString(post.date)} by #{post.author in info.users ? info.users[post.author].name : post.author}
 								a(href="posts/#{post.name}#comments") #{info.commentCount[i]} comments
 								- if( post.trackbacks.length > 0 )


### PR DESCRIPTION
The blog name and description can now be changed in the active configuration.
The information necessary to render WebAdmin pages is now encapsulated in structs.
Previewing now works.
Made Markdown filtering optional, but enabled by default.
Laid groundwork for adding more text filters.

Sorry for the squashed commit.