### PR TITLE
fix for compile error in issue #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: d
 
 d:
+  - dmd-2.072.0
   - dmd-2.071.1
   - dmd-2.068.2
-  - dmd-2.067.1
 
 services:
   - mongodb

--- a/views/vibelog.admin.editconfig.dt
+++ b/views/vibelog.admin.editconfig.dt
@@ -10,6 +10,7 @@ block vibelog-localnav
 
 block vibelog-content
 	form(action="./", method="POST")
+		- import std.array;
 		- if( info.config.name == "global" )
 			p
 				label(for="categories") Categories

--- a/views/vibelog.admin.editpost.dt
+++ b/views/vibelog.admin.editpost.dt
@@ -97,6 +97,7 @@ block vibelog-content
 							label(for="preview-checkbox") Preview
 						p
 							label(for="filters-field") Filters
+							- import std.array;
 							input#filters-field(type="text", name="filters", onchange="previewUpdate();", style="width: auto;", autocomplete="off", value='#{info.post ? info.post.filters.join(" ") : "markdown"}')
 					td
 						#message-area


### PR DESCRIPTION
Fixes the compilation error where two diet templates are unable to access `join()` in `std.array` when integrating vibelog in custom projects, as mentioned in issue #14.